### PR TITLE
Add .stylelintignore

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,12 @@
+**/*.js
+node_modules/*
+assets/js/*.min.js
+assets/**/*.css
+**/*.js
+**/*.json
+**/*.mustache
+**/*.jpeg
+**/*.svg
+test/*
+*.md
+LICENSE

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "atlas-guide": "bin/atlas-guide.js"
   },
   "scripts": {
-    "lint": "eslint ./ && stylelint assets/**/*.scss",
+    "lint": "eslint ./ && stylelint ./",
     "test": "nyc mocha",
     "coverage": "nyc report --reporter=lcov --reporter=text-lcov",
     "build": "gulp build",


### PR DESCRIPTION
@dimanech Hey ! 👋🏼 , I'm part of codeclimate's team. I have been told that you are running into error when running stylelint through codeclimate's platform. 

The error that you are suffering comes from stylelint's core, and it's occurring because stylelint is being run against your entire repo and it's failing to analyze a javascript file.

From your package.json I noticed that you are using stylelint as follows:
```js
"lint": "eslint ./ && stylelint assets/**/*.scss"
```

There is no way to specify to codeclimate to over which files you want to run stylelint against, but you can indicate it which files you want to ignore. For your usecase I think it will be easer to maintain if you keep that information in an `.stlylelintignore` config file.

Alternatively, you can accomplish the same modifying your `.codeclimate.yml` as follows:
```YAML
plugins:
  stylelint:
    enabled: true
    exclude_patterns:
      - ".stylelintignore"
      - "**/*.js"
      - "node_modules/*"
      - "assets/js/*.min.js"
      - "assets/**/*.css"
      - "**/*.js"
      - "**/*.json"
      - "**/*.mustache"
      - "**/*.jpeg"
      - "**/*.svg"
      - "test/*"
      - "*.md"
      - "LICENSE"
  eslint:
    enabled: true
checks:
  method-lines:
    config:
      threshold: 35
exclude_paths:
- "node_modules"
- "test"
- ".githooks"
- "assets/js"
- "assets/css"
```

I hope you can find this useful. 